### PR TITLE
Cart: Make array from cart items to process for removal

### DIFF
--- a/MEALS_WF_review_order_footer.js
+++ b/MEALS_WF_review_order_footer.js
@@ -122,7 +122,8 @@ function createCartItems() {
 
     // Remove children current cart or loader
     if (reviewItemContainer.children.length) {
-        reviewItemContainer.childNodes.forEach((child) => child.remove())
+        const reviewItems = Array.from(reviewItemContainer.childNodes)
+        reviewItems.forEach((child) => child.remove())
     }
 
     cartItems.forEach((item) => {


### PR DESCRIPTION
WHAT: Use Array.from on childNodes

WHY: childNodes is updated on the go. Need to duplicate to an array in order to be compatible with forEach without unexpected behaviour.