### PR TITLE
Cart: Add id to Vercel payload

### DIFF
--- a/MEAL_WF_project_footer.js
+++ b/MEAL_WF_project_footer.js
@@ -1003,7 +1003,8 @@ function postOrder(url) {
                 employeeName: employeeName,
                 quantity: current.quantity,
                 price: current.price_each,
-                code: current.code,
+                code: current.code, // Preserving old key to avoid breaking change.
+                id: current.code,
                 transaction: FC.json.transaction_id,
                 email: employeeEmail,
             }


### PR DESCRIPTION
Cart: Add id to Vercel payload
WHAT: Modified object in postOrder params.
WHY: To pass product ids to AirTable as id attribute.